### PR TITLE
Decide encoding of files with BOM (If exists)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- insertion marker -->
 ## Unreleased
 
-<small>[Compare with latest](https://github.com/billyeatcookies/Biscuit/compare/v2.5.0...HEAD)</small>
+<small>[Compare with latest](https://github.com/billyeatcookies/Biscuit/compare/v2.5.1...HEAD)</small>
 
 <!-- insertion marker -->
+## [v2.5.1](https://github.com/billyeatcookies/Biscuit/releases/tag/v2.5.1) - 2023-07-10
+
+<small>[Compare with v2.5.0](https://github.com/billyeatcookies/Biscuit/compare/v2.5.0...v2.5.1)</small>
+
 ## [v2.5.0](https://github.com/billyeatcookies/Biscuit/releases/tag/v2.5.0) - 2023-07-10
 
 <small>[Compare with 2.0.0](https://github.com/billyeatcookies/Biscuit/compare/2.0.0...v2.5.0)</small>

--- a/biscuit/app.py
+++ b/biscuit/app.py
@@ -210,6 +210,7 @@ class App(tk.Tk):
             if editor.content and editor.content.editable:
                 self.statusbar.toggle_editmode(True)
                 active_text = editor.content.text
+                self.statusbar.set_encoding(active_text.encoding)
                 return self.statusbar.set_line_col_info(
                     active_text.line, active_text.column, active_text.get_selected_count())
 

--- a/biscuit/core/components/editors/texteditor/__init__.py
+++ b/biscuit/core/components/editors/texteditor/__init__.py
@@ -32,9 +32,6 @@ class TextEditor(BaseEditor):
         self.text.grid(row=0, column=1, sticky=tk.NSEW)
         self.scrollbar.grid(row=0, column=3, sticky=tk.NS)
 
-        if self.exists:
-            self.text.load_file()
-
         self.text.bind("<<Change>>", self.on_change)
         self.text.bind("<Configure>", self.on_change)
 

--- a/biscuit/core/components/editors/texteditor/highlighter.py
+++ b/biscuit/core/components/editors/texteditor/highlighter.py
@@ -10,7 +10,7 @@ class Highlighter:
         self.base = master.base
 
         try:
-            self.lexer = get_lexer_for_filename(os.path.basename(master.path))
+            self.lexer = get_lexer_for_filename(os.path.basename(master.path), inencoding=master.encoding, encoding=master.encoding)
         except ClassNotFound:
             self.lexer = None
 

--- a/biscuit/core/layout/statusbar/__init__.py
+++ b/biscuit/core/layout/statusbar/__init__.py
@@ -124,3 +124,6 @@ class Statusbar(Frame):
 
     def set_line_col_info(self, line, col, selected):
         self.line_col_info.change_text(text="Ln {0}, Col {1}{2}".format(line, col, f" ({selected} selected)" if selected else ""))
+
+    def set_encoding(self, encoding):
+        self.encoding.change_text(text=encoding.upper())


### PR DESCRIPTION
fix #71 

---

- BOM (if exists) is used to decide the encoding of file
- BOM is not written as plain text to the text editor