### PR TITLE
feat: Add 12/24 hour option for statusbar clock

### DIFF
--- a/biscuit/core/layout/statusbar/__init__.py
+++ b/biscuit/core/layout/statusbar/__init__.py
@@ -106,12 +106,14 @@ class Statusbar(Frame):
         self.notif.pack(side=tk.RIGHT, padx=(0, 10))
 
         # clock
+        self.clock = SClock(self, text="H:M:S", description="Time")
         self.time_actionset = ActionSet(
             "Configure clock format", "time:",
-            [("12 hours", lambda e=None: print("time 12 hours", e)),
-            ("24 hours", lambda e=None: print("time 24 hours", e)),],
+            [("12 hours", lambda e=None: self.clock.use_24_hour_format(False)),
+            ("24 hours", lambda e=None: self.clock.use_24_hour_format(True)),],
         )
-        self.clock = SClock(self, text="H:M:S", function=lambda: self.base.palette.show_prompt('time:'), description="Time")
+        self.base.palette.register_actionset(lambda: self.time_actionset)
+        self.clock.change_function(function=lambda: self.base.palette.show_prompt('time:'))
         self.clock.set_pack_data(side=tk.RIGHT)
         self.clock.show()
 

--- a/biscuit/core/layout/statusbar/utils/clock.py
+++ b/biscuit/core/layout/statusbar/utils/clock.py
@@ -3,13 +3,18 @@ import time
 from .button import SButton
 
 
-#TODO 12/24 actionset config
 class SClock(SButton):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        self.hour_24_format = True
         self.update()
     
     def update(self) -> None:
-        time_live = time.strftime("%I:%M %p")
+        time_live = time.strftime("%H:%M:%S" if self.hour_24_format else "%I:%M:%S")
         self.text_label.config(text=time_live) 
         self.after(200, self.update)
+
+    def use_24_hour_format(self, flag: str) -> None:
+        "Use 24 hour format for clock"
+        self.hour_24_format = flag
+        self.update()


### PR DESCRIPTION
## Features implemented

- clock can now also use 12 hour format
- use palette to pick the formats

![image](https://github.com/billyeatcookies/Biscuit/assets/70792552/2d302b80-9606-4bf5-9088-4a475bbb21eb)

![image](https://github.com/billyeatcookies/Biscuit/assets/70792552/f66340d7-8a90-4e0c-9744-b197f33545c9)
![image](https://github.com/billyeatcookies/Biscuit/assets/70792552/afeaef30-ffdf-4e93-8353-54abd0bfaada)
