### PR TITLE
One-line docstring should fit on one line with quotes

### DIFF
--- a/biscuit/core/components/editors/editor.py
+++ b/biscuit/core/components/editors/editor.py
@@ -2,9 +2,7 @@ from ..utils import Frame, IconButton
 
 
 class BaseEditor(Frame):
-    """
-    Base class for editors.
-    """
+    """Base class for editors."""
     def __init__(self, master, path=None, path2=None, editable=True, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.config(**self.base.theme.editors)

--- a/biscuit/core/components/editors/languages.py
+++ b/biscuit/core/components/editors/languages.py
@@ -1,7 +1,5 @@
 class Languages:
-    """
-    Holds all available languages. To be passed to Editor during initialization.
-    """
+    """Holds all available languages. To be passed to Editor during initialization."""
     ABAP = "abap"
     AMDGPU = "amdgpu"
     APL = "apl"

--- a/biscuit/core/components/editors/texteditor/text.py
+++ b/biscuit/core/components/editors/texteditor/text.py
@@ -13,10 +13,7 @@ from .syntax import Syntax
 
 
 class Text(Text):
-    """
-    Improved Text widget
-
-    """
+    """Improved Text widget"""
     def __init__(self, master, path=None, exists=True, minimalist=False, language=None, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.path = path
@@ -216,17 +213,13 @@ class Text(Text):
         self.insert("insert", new_word)
     
     def check_autocomplete_keys(self, event):
-        """
-        Helper function for autocomplete.show to check triggers
-        """
+        """Helper function for autocomplete.show to check triggers"""
         return True if event.keysym not in [
             "BackSpace", "Escape", "Return", "Tab", "space", 
             "Up", "Down", "Control_L", "Control_R"] else False 
     
     def cursor_screen_location(self):
-        """
-        Helper function for autocomplete.show to detect cursor location
-        """
+        """Helper function for autocomplete.show to detect cursor location"""
         pos_x, pos_y = self.winfo_rootx(), self.winfo_rooty()
 
         cursor = tk.INSERT

--- a/biscuit/core/components/games/game.py
+++ b/biscuit/core/components/games/game.py
@@ -4,9 +4,7 @@ from biscuit.core.components.utils import Frame, IconButton
 
 
 class BaseGame(Frame):
-    """
-    Base class for games.
-    """
+    """Base class for games."""
     def __init__(self, master, path=None, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.config(**self.base.theme.editors)

--- a/biscuit/core/components/lsp/test.py
+++ b/biscuit/core/components/lsp/test.py
@@ -14,19 +14,13 @@ class LSP:
         self.master = master
 
     def get_language(self, filename) -> None:
-        """
-        Get the language of a file
-        """
+        """Get the language of a file"""
         ...
         
     def get_language_name(self, language) -> None:
-        """
-        Get the name of a language
-        """
+        """Get the name of a language"""
         ...
     
     def get_language_extensions(self, language) -> None:
-        """
-        Get the extensions of a language
-        """
+        """Get the extensions of a language"""
         ...

--- a/biscuit/core/components/utils/__init__.py
+++ b/biscuit/core/components/utils/__init__.py
@@ -1,6 +1,4 @@
-"""
-Various types of widgets/functions used across the editor
-"""
+"""Various types of widgets/functions used across the editor"""
 
 from .bubble import Bubble
 from .button import Button

--- a/biscuit/core/components/utils/button.py
+++ b/biscuit/core/components/utils/button.py
@@ -4,9 +4,7 @@ from .menubutton import Menubutton
 
 
 class Button(Menubutton):
-    """
-    A Flat style button 
-    """
+    """A Flat style button"""
     def __init__(self, master, text, command=lambda _: None, *args, **kwargs) -> None:
         super().__init__(master, text=text, *args, **kwargs)
         self.config(pady=5, font=("Segoi UI", 10), **self.base.theme.utils.button)

--- a/biscuit/core/components/utils/canvas.py
+++ b/biscuit/core/components/utils/canvas.py
@@ -2,9 +2,7 @@ import tkinter as tk
 
 
 class Canvas(tk.Canvas):
-    """
-    normal canvas with reference to base
-    """
+    """normal canvas with reference to base"""
     def __init__(self, master, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.master = master

--- a/biscuit/core/components/utils/frame.py
+++ b/biscuit/core/components/utils/frame.py
@@ -9,9 +9,7 @@ if typing.TYPE_CHECKING:
 
 
 class Frame(tk.Frame):
-    """
-    normal frame with reference to base
-    """
+    """normal frame with reference to base"""
     def __init__(self, master, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.master = master

--- a/biscuit/core/components/utils/icon.py
+++ b/biscuit/core/components/utils/icon.py
@@ -5,9 +5,7 @@ from .label import Label
 
 
 class Icon(Label):
-    """
-    Button with only an icon
-    """
+    """Button with only an icon"""
     def __init__(self, master, icon, iconsize=14, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.icon = icon

--- a/biscuit/core/components/utils/iconbutton.py
+++ b/biscuit/core/components/utils/iconbutton.py
@@ -5,9 +5,7 @@ from .menubutton import Menubutton
 
 
 class IconButton(Menubutton):
-    """
-    Button with only an icon
-    """
+    """Button with only an icon"""
     def __init__(self, master, icon, event=lambda *_:..., icon2=None, iconsize=14, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.config(**self.base.theme.utils.iconbutton)

--- a/biscuit/core/components/utils/label.py
+++ b/biscuit/core/components/utils/label.py
@@ -12,18 +12,14 @@ class Label(tk.Label):
 
 
 class WrappingLabel(Label):
-    """
-    a type of Label that automatically adjusts the wrap to the size
-    """
+    """a type of Label that automatically adjusts the wrap to the size"""
     def __init__(self, master, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.bind('<Configure>', lambda e: self.config(wraplength=self.winfo_width()))
 
 
 class TruncatedLabel(Frame):
-    """
-    NOTE: Doesnt work currently
-    """
+    """NOTE: Doesnt work currently"""
     def __init__(self, master, text, *args, **kwargs) -> None:
         super().__init__(master)
         self.text = text

--- a/biscuit/core/components/utils/menubutton.py
+++ b/biscuit/core/components/utils/menubutton.py
@@ -2,9 +2,7 @@ import tkinter as tk
 
 
 class Menubutton(tk.Menubutton):
-    """
-    normal menubutton with reference to base
-    """
+    """normal menubutton with reference to base"""
     def __init__(self, master, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.master = master

--- a/biscuit/core/components/utils/text.py
+++ b/biscuit/core/components/utils/text.py
@@ -6,9 +6,7 @@ if typing.TYPE_CHECKING:
 
 
 class Text(tk.Text):
-    """
-    Text widget with reference to base
-    """
+    """Text widget with reference to base"""
     def __init__(self, master, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.master = master

--- a/biscuit/core/components/views/view.py
+++ b/biscuit/core/components/views/view.py
@@ -2,9 +2,7 @@ from biscuit.core.components.utils import Frame
 
 
 class View(Frame):
-    """
-    View is a container of content that can appear in the sidebar or panel
-    """
+    """View is a container of content that can appear in the sidebar or panel"""
     def __init__(self, master, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.config(**self.base.theme.views)

--- a/biscuit/core/layout/__init__.py
+++ b/biscuit/core/layout/__init__.py
@@ -24,9 +24,7 @@ if typing.TYPE_CHECKING:
 
 
 class Root(Frame):
-    """
-    Root frame holds Menubar, BaseFrame, and Statusbar
-    """
+    """Root frame holds Menubar, BaseFrame, and Statusbar"""
     def __init__(self, base: App, *args, **kwargs) -> None:
         super().__init__(base, *args, **kwargs)
         self.config(bg=self.base.theme.border)

--- a/biscuit/core/layout/base/__init__.py
+++ b/biscuit/core/layout/base/__init__.py
@@ -24,9 +24,7 @@ from .sidebar import Sidebar
 
 
 class BaseFrame(Frame):
-    """
-    Main frame holds Sidebar and ContentPane
-    """
+    """Main frame holds Sidebar and ContentPane"""
     def __init__(self, master: Root, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.config(bg=self.base.theme.border)

--- a/biscuit/core/layout/base/content/__init__.py
+++ b/biscuit/core/layout/base/content/__init__.py
@@ -27,9 +27,7 @@ from .panel import Panel
 
 
 class ContentPane(Frame):
-    """
-    Main frame holds ContentPane and Panel
-    """
+    """Main frame holds ContentPane and Panel"""
     def __init__(self, master: BaseFrame, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.config(bg=self.base.theme.border)

--- a/biscuit/core/layout/base/content/editors/__init__.py
+++ b/biscuit/core/layout/base/content/editors/__init__.py
@@ -33,9 +33,7 @@ from .empty import Empty
 
 
 class EditorsPane(Frame):
-    """
-    Tabbed container for editors.
-    """
+    """Tabbed container for editors."""
     def __init__(self, master: ContentPane, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.config(bg=self.base.theme.border)

--- a/biscuit/core/layout/base/content/panel/__init__.py
+++ b/biscuit/core/layout/base/content/panel/__init__.py
@@ -26,9 +26,7 @@ from .panelbar import Panelbar
 
 
 class Panel(Frame):
-    """
-    Tabbed container for views.
-    """
+    """Tabbed container for views."""
     def __init__(self, master: ContentPane, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.grid_rowconfigure(1, weight=1)

--- a/biscuit/core/layout/base/content/panel/tabs.py
+++ b/biscuit/core/layout/base/content/panel/tabs.py
@@ -14,9 +14,7 @@ from .tab import Tab
 
 
 class Tabs(Frame):
-    """
-    Holder for the tabs shown in panelbar
-    """
+    """Holder for the tabs shown in panelbar"""
     def __init__(self, master: Panelbar, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.config(**self.base.theme.layout.base.content.panel.bar)

--- a/biscuit/core/layout/base/sidebar/__init__.py
+++ b/biscuit/core/layout/base/sidebar/__init__.py
@@ -31,9 +31,7 @@ from .slots import Slots
 
 
 class Sidebar(Frame):
-    """
-    Vertically slotted container for views.
-    """
+    """Vertically slotted container for views."""
     def __init__(self, master: BaseFrame, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
         self.config(bg=self.base.theme.border)

--- a/biscuit/core/settings/__init__.py
+++ b/biscuit/core/settings/__init__.py
@@ -62,9 +62,7 @@ class Settings:
         self.gen_actionset()
 
     def gen_actionset(self) -> None:
-        """
-        Generates the action set with predefined commands and registered commands.
-        """
+        """Generates the action set with predefined commands and registered commands."""
         from biscuit.core.components import ActionSet
         self._actionset = ActionSet(
             "Show and run commands", ">", self.commands + get_games(self.base)
@@ -96,7 +94,5 @@ class Settings:
 
     @property
     def actionset(self):
-        """
-        Returns the generated action set.
-        """
+        """Returns the generated action set."""
         return self._actionset

--- a/biscuit/core/settings/config/__init__.py
+++ b/biscuit/core/settings/config/__init__.py
@@ -9,9 +9,7 @@ from .theme import Dark, Light
 
 
 class Config:
-    """
-    Loads and manages configurations for biscuit.
-    """
+    """Loads and manages configurations for biscuit."""
     def __init__(self, master) -> None:
         self.base = master.base
         

--- a/biscuit/core/settings/config/bindings/loader.py
+++ b/biscuit/core/settings/config/bindings/loader.py
@@ -4,9 +4,7 @@ import toml
 
 
 class BindingsLoader:
-    """
-    Loads bindings for biscuit from json file.
-    """
+    """Loads bindings for biscuit from json file."""
     def __init__(self, master) -> None:
         self.base = master.base
 


### PR DESCRIPTION
If a docstring fits in a single line (72 characters according to PEP8), it is
recommended to have the quotes on the same line.