### PR TITLE
feat: Ask user to save the file before they close the tab #280

### DIFF
--- a/biscuit/core/commands.py
+++ b/biscuit/core/commands.py
@@ -90,6 +90,7 @@ class Commands:
         self.base.close_active_directory()
 
     def quit(self, *_) -> None:
+        self.base.on_close_app()
         self.base.destroy()
 
     def toggle_maximize(self, *_) -> None:

--- a/biscuit/core/components/editors/texteditor/text.py
+++ b/biscuit/core/components/editors/texteditor/text.py
@@ -32,7 +32,7 @@ class Text(BaseText):
 
     def __init__(self, master: TextEditor, path: str=None, exists: bool=True, minimalist: bool=False, standalone: bool=False, language: str=None, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
-        self.master = master
+        self.master: TextEditor = master
         self.path = path
         self.filename = os.path.basename(path) if path else None
         self.encoding = 'utf-8'
@@ -901,7 +901,7 @@ class Text(BaseText):
             # If the queue is empty, schedule the next check after a short delay
             self.master.after(100, self.process_queue)
         
-        self.master.event_generate("<<FileLoaded>>", when="tail")
+        self.master.file_loaded()
     
     def custom_get(self, start, end):
         content = self.get(start, end)

--- a/biscuit/core/gui.py
+++ b/biscuit/core/gui.py
@@ -60,6 +60,8 @@ class GUIManager(Tk, ConfigManager):
 
         self.setup_floating_widgets()
         self.setup_root()
+
+        self.protocol("WM_DELETE_WINDOW", self.on_close_app)
         
     def setup_root(self):
         # the very parent of all GUI parts
@@ -137,6 +139,9 @@ class GUIManager(Tk, ConfigManager):
 
     def register_onfocus(self, fn) -> None:
         self.onfocus_callbacks.append(fn)
+    
+    def on_close_app(self) -> None:
+        self.editorsmanager.delete_all_editors()
 
     def on_focus(self, *_) -> None:
         for fn in self.onfocus_callbacks:

--- a/biscuit/core/layout/base/content/editors/__init__.py
+++ b/biscuit/core/layout/base/content/editors/__init__.py
@@ -74,19 +74,23 @@ class EditorsPane(Frame):
 
     def add_default_editors(self) -> None:
         "Adds all default editors"
+
         self.add_editors(self.default_editors)
     
     def add_welcome(self) -> None:
         "Shows welcome tab"
+
         self.add_editor(Welcome(self))
 
     def add_editors(self, editors: list[Editor]) -> None:
         "Append <Editor>s to list. Create tabs for them."
+        
         for editor in editors:
             self.add_editor(editor)
 
     def add_editor(self, editor: Union[Editor,BaseEditor]) -> Editor | BaseEditor:
         "Appends a editor to list. Create a tab."
+
         self.active_editors.append(editor)
         if editor.content:
             editor.content.create_buttons(self.editorsbar.container)
@@ -97,9 +101,12 @@ class EditorsPane(Frame):
 
     def delete_all_editors(self) -> None:
         "Permanently delete all editors."
-        for editor in self.active_editors:
-            editor.destroy()
 
+        for tab in self.tabs.tabs:
+            if e := tab.editor:
+                self.tabs.save_unsaved_changes(e)
+                e.destroy()
+        
         self.editorsbar.clear()
         self.tabs.clear_all_tabs()
         self.active_editors.clear()
@@ -108,6 +115,7 @@ class EditorsPane(Frame):
 
     def reopen_active_editor(self) -> None:
         "Reopen the active editor"
+        
         if self.active_editor and self.active_editor.exists:
             self.delete_editor(self.active_editor)
             self.update()

--- a/biscuit/core/layout/base/content/editors/tab.py
+++ b/biscuit/core/layout/base/content/editors/tab.py
@@ -8,7 +8,6 @@ if typing.TYPE_CHECKING:
 
 import os
 import tkinter as tk
-from hashlib import md5
 
 from biscuit.core.utils import Frame, Icon, IconButton
 
@@ -37,8 +36,6 @@ class Tab(Frame):
 
         self.bind("<Enter>", self.on_hover)
         self.bind("<Leave>", self.off_hover)
-
-        self.content_hash = ""
 
     def close(self, *_) -> None:
         self.master.close_tab(self)
@@ -78,14 +75,3 @@ class Tab(Frame):
             self.apply_color(self.hbg)
             self.closebtn.config(activeforeground=self.hfg)
             self.selected = True
-            self.content_hash = self.calculate_content_hash()
-
-    def calculate_content_hash(self):
-        """ Calculate the hash of the editor content """
-        
-        if self.editor.content: # Welcome editor returns a None value
-                 
-            # Cannot get contents when using self.editor.content.get(..),
-            # so had to directly call get()
-            editor_contents = self.editor.content.text.get(index1="1.0", index2="end-1c")
-            return md5(editor_contents.encode()).hexdigest()

--- a/biscuit/core/layout/base/content/editors/tab.py
+++ b/biscuit/core/layout/base/content/editors/tab.py
@@ -8,6 +8,7 @@ if typing.TYPE_CHECKING:
 
 import os
 import tkinter as tk
+from hashlib import md5
 
 from biscuit.core.utils import Frame, Icon, IconButton
 
@@ -36,6 +37,8 @@ class Tab(Frame):
 
         self.bind("<Enter>", self.on_hover)
         self.bind("<Leave>", self.off_hover)
+
+        self.content_hash = ""
 
     def close(self, *_) -> None:
         self.master.close_tab(self)
@@ -75,3 +78,14 @@ class Tab(Frame):
             self.apply_color(self.hbg)
             self.closebtn.config(activeforeground=self.hfg)
             self.selected = True
+            self.content_hash = self.calculate_content_hash()
+
+    def calculate_content_hash(self):
+        """ Calculate the hash of the editor content """
+        
+        if self.editor.content: # Welcome editor returns a None value
+                 
+            # Cannot get contents when using self.editor.content.get(..),
+            # so had to directly call get()
+            editor_contents = self.editor.content.text.get(index1="1.0", index2="end-1c")
+            return md5(editor_contents.encode()).hexdigest()

--- a/biscuit/core/layout/base/content/editors/tabs.py
+++ b/biscuit/core/layout/base/content/editors/tabs.py
@@ -32,17 +32,19 @@ class Tabs(Frame):
 
     def close_active_tab(self) -> None:
         self.close_tab(self.active_tab)
+    
+    def save_unsaved_changes(self, e) -> None:
+        if e.content and e.content.editable and e.content.unsaved_changes:
+            if askyesno(f"Unsaved changes", f"Do you want to save the changes you made to {e.filename}"):
+                if e.exists:
+                    e.save()
+                else:
+                    self.base.commands.save_as()
+                print(f"Saved changes to {e.path}.")
 
     def close_tab(self, tab: Tab) -> None:
         if e := tab.editor:
-            # checking if its a text editor
-            if e.content and e.content.editable and e.content.unsaved_changes:
-                if askyesno(f"Unsaved changes", f"Do you want to save the changes you made to {tab.editor.filename}"):
-                    if e.exists:
-                        e.save()
-                    else:
-                        self.base.commands.save_as()
-                    print(f"Saved changes to {e.path}.")
+            self.save_unsaved_changes(e)
         
         try:
             i = self.tabs.index(tab)

--- a/biscuit/core/layout/base/content/editors/tabs.py
+++ b/biscuit/core/layout/base/content/editors/tabs.py
@@ -6,7 +6,9 @@ if typing.TYPE_CHECKING:
     from . import Editorsbar
     from biscuit.core.components import Editor
 
+import os
 import tkinter as tk
+from tkinter.messagebox import askyesno
 
 from biscuit.core.utils import Frame
 
@@ -32,6 +34,13 @@ class Tabs(Frame):
         self.close_tab(self.active_tab)
 
     def close_tab(self, tab: Tab) -> None:
+        
+        if self.content_has_changed():
+            if askyesno("Save File", f"You have unsaved changes. Do you want to save {tab.editor.filename}"):
+                filepath = os.path.join(self.base.active_directory, tab.editor.filename)
+                tab.editor.save(filepath)
+                print(f"Saved changes to {filepath}.")
+        
         try:
             i = self.tabs.index(tab)
         except ValueError:
@@ -87,3 +96,11 @@ class Tabs(Frame):
             if tab.editor.path == path:
                 tab.select()
                 return tab.editor
+
+    def content_has_changed(self):
+        current_file_hash = self.active_tab.calculate_content_hash()
+        if current_file_hash == self.active_tab.content_hash:
+            # No changes has been made in the editor
+            return False
+        else:
+            return True

--- a/biscuit/core/layout/base/content/editors/tabs.py
+++ b/biscuit/core/layout/base/content/editors/tabs.py
@@ -34,12 +34,15 @@ class Tabs(Frame):
         self.close_tab(self.active_tab)
 
     def close_tab(self, tab: Tab) -> None:
-        
-        if self.content_has_changed():
-            if askyesno("Save File", f"You have unsaved changes. Do you want to save {tab.editor.filename}"):
-                filepath = os.path.join(self.base.active_directory, tab.editor.filename)
-                tab.editor.save(filepath)
-                print(f"Saved changes to {filepath}.")
+        if e := tab.editor:
+            # checking if its a text editor
+            if e.content and e.content.editable and e.content.unsaved_changes:
+                if askyesno(f"Unsaved changes", f"Do you want to save the changes you made to {tab.editor.filename}"):
+                    if e.exists:
+                        e.save()
+                    else:
+                        self.base.commands.save_as()
+                    print(f"Saved changes to {e.path}.")
         
         try:
             i = self.tabs.index(tab)
@@ -96,11 +99,3 @@ class Tabs(Frame):
             if tab.editor.path == path:
                 tab.select()
                 return tab.editor
-
-    def content_has_changed(self):
-        current_file_hash = self.active_tab.calculate_content_hash()
-        if current_file_hash == self.active_tab.content_hash:
-            # No changes has been made in the editor
-            return False
-        else:
-            return True


### PR DESCRIPTION
fix #280

In your [comment](https://github.com/billyeatcookies/biscuit/issues/280#issuecomment-2051108903), you also mentioned the idea of making a whole app destroy event. I have not implemented it in here, but i guess when the whole app is closed/destroyed, we can get the list of active editors and then just manually close them? I guess closing them will trigger the [close_tab()](https://github.com/vyshnav-vinod/biscuit/blob/3c6bf3df728f3dcbd1e390198730f51987c2fe0c/biscuit/core/layout/base/content/editors/tabs.py#L36) function of the tabs and it should trigger the save dialog??